### PR TITLE
feat(Generate Instance): Generate an instance of any entity with FirstName and LastName properties

### DIFF
--- a/Diverse.Tests/FuzzerWithClassShould.cs
+++ b/Diverse.Tests/FuzzerWithClassShould.cs
@@ -1,0 +1,35 @@
+using NFluent;
+using NUnit.Framework;
+
+namespace Diverse.Tests
+{
+    [TestFixture]
+    public class FuzzerWithClassShould
+    {
+        [Test]
+        public void Be_able_to_generate_a_diverse_firstname_for_any_object_containing_a_firstname_property()
+        {
+            Fuzzer fuzzer = new Fuzzer(23984398);
+
+            Player dummyClass = fuzzer.GenerateInstance<Player>();
+
+            Check.That(dummyClass.FirstName).IsEqualTo("Kevin");
+        }
+
+        [Test]
+        public void Be_able_to_generate_a_diverse_lastname_for_any_object_containing_a_lastname_property()
+        {
+            Fuzzer fuzzer = new Fuzzer(23984398);
+
+            Player dummyClass = fuzzer.GenerateInstance<Player>();
+
+            Check.That(dummyClass.LastName).IsEqualTo("Fantasia");
+        }
+    }
+
+    internal class Player
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/Diverse/Fuzzer.cs
+++ b/Diverse/Fuzzer.cs
@@ -456,8 +456,18 @@ namespace Diverse
             //    throw new ArgumentException(message, paramName);
             //}
 
-
             return GenerateDateTimeBetween(minDateTime, maxDateTime);
+        }
+        public T GenerateInstance<T>()
+        {
+            Func<string> defaultGenerateFirstName = () => GenerateFirstName();
+
+            Generators generators = new Generators() {
+                NameGenerator = defaultGenerateFirstName,
+                LastNameGenerator = GenerateLastName
+            };
+
+            return new FuzzerClass().GenerateInstance<T>(generators);
         }
     }
 }

--- a/Diverse/FuzzerClass.cs
+++ b/Diverse/FuzzerClass.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Diverse
+{
+    public class FuzzerClass
+    {
+        public T GenerateInstance<T>(Generators generators)
+        {
+            Type genericType = typeof(T);
+            T instance = (T)Activator.CreateInstance(genericType);
+
+            IEnumerable<PropertyInfo> stringProperties = GetWritableStringProperties(genericType);
+            
+            foreach (var stringPropertyInfo in stringProperties)
+            {
+                SetProperty<T>(generators, instance, stringPropertyInfo);
+            }
+
+            return instance;
+        }
+
+        private static IEnumerable<PropertyInfo> GetWritableStringProperties(Type genericType)
+        {
+            return genericType.GetProperties().Where(prop => prop.PropertyType == typeof(String) && prop.CanWrite);
+        }
+
+        private void SetProperty<T>(Generators generators, T instance, PropertyInfo stringPropertyInfo)
+        {
+            string firstName = generators.NameGenerator();
+            if(stringPropertyInfo.Name.Contains("FirstName"))
+            {
+                stringPropertyInfo.SetValue(instance, firstName);
+            }
+            else if(stringPropertyInfo.Name.Contains("LastName"))
+            {
+                stringPropertyInfo.SetValue(instance, generators.LastNameGenerator(firstName));
+            }
+        }
+    }
+}

--- a/Diverse/Generators.cs
+++ b/Diverse/Generators.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Diverse
+{
+    public class Generators
+    {
+        public Func<string> NameGenerator { get; set; }
+        public Func<string, string> LastNameGenerator { get; set; }
+    }
+}

--- a/Diverse/IFuzz.cs
+++ b/Diverse/IFuzz.cs
@@ -5,7 +5,7 @@ namespace Diverse
     /// <summary>
     /// Interface to build your own <see cref="Fuzzer"/> through extension methods.
     /// </summary>
-    public interface IFuzz : IFuzzNumbers, IFuzzPersons, IFuzzDatesAndTime
+    public interface IFuzz : IFuzzNumbers, IFuzzPersons, IFuzzDatesAndTime, IFuzzClass
     {
         /// <summary>
         /// Gets a <see cref="Random"/> instance to use if you want your extensible Fuzzer to be deterministic when providing a seed.

--- a/Diverse/IFuzzClass.cs
+++ b/Diverse/IFuzzClass.cs
@@ -1,0 +1,14 @@
+namespace Diverse
+{
+    /// <summary>
+    /// Fuzz numbers.
+    /// </summary>
+    public interface IFuzzClass
+    {
+        /// <summary>
+        /// Generates an instance of T for your tests
+        /// </summary>
+        /// <returns>An instance with string properties set to random strings</returns>
+        T GenerateInstance<T>();
+    }
+}


### PR DESCRIPTION
The idea is to be able to avoid mapping when using a entity to be mapped to the Diverse.Person. The generateInstance automatically inspect the object to generate a FirstName and/or a LastName if present.

Coupled with the string generation (other Pull Request) it can became quite powerful to generate instances to play with in test.