### PR TITLE
Add pick one overload

### DIFF
--- a/Diverse.Tests/CollectionFuzzerShould.cs
+++ b/Diverse.Tests/CollectionFuzzerShould.cs
@@ -20,6 +20,18 @@ namespace Diverse.Tests
                 Check.That(chosenOne).IsOneOf(candidates);
             }
         }
+        
+        [Test]
+        public void Be_able_to_PickOneFrom_using_params_api()
+        {
+            var fuzzer = new Fuzzer();
+
+            for (var i = 0; i < 10; i++)
+            {
+                var chosenOne = fuzzer.PickOneFrom("one", "two", "three", "four", "five");
+                Check.That(chosenOne).IsOneOf("one", "two", "three", "four", "five");
+            }
+        }
 
         [Test]
         public void Throw_an_Exception_when_list_of_candidates_is_null()

--- a/Diverse/Collections/CollectionFuzzer.cs
+++ b/Diverse/Collections/CollectionFuzzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Diverse/FuzzerExtensions.cs
+++ b/Diverse/FuzzerExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+
+namespace Diverse
+{
+    public static class FuzzerExtensions
+    {
+        /// <summary>
+        /// Randomly pick one element from a given collection.
+        /// </summary>
+        /// <param name="fuzzer"></param>
+        /// <param name="candidates"></param>
+        /// <returns>One of the elements from the candidates collection.</returns>
+        public static T PickOneFrom<T>(this IFuzzFromCollections fuzzer, params T[] candidates)
+        {
+            return fuzzer.PickOneFrom(candidates.ToList());
+        }
+    }
+}


### PR DESCRIPTION
When you don't have to share the list of values among many tests, the actual `PickOne` implementation can be improved with the `params`keyword.

For instance, I'd prefer this : 

```csharp 
    public class MyServiceShould {
        [Fact]
        public async Task ComputeSomeStuff() 
        {
              var fuzzer = new Fuzzer();

              var candidate = fuzzer.PickOneFrom("value1", "value2", "value3");

              var result = await Compute(candidate);

              CheckResultsValid(result);
        }
   }
```

To this : 

```csharp 
    public class MyServiceShould {
        [Fact]
        public async Task ComputeSomeStuff() 
        {
              var fuzzer = new Fuzzer();

              var candidate = fuzzer.PickOneFrom(new [] { "value1", "value2", "value3" });

              var result = await Compute(candidate);

              CheckResultsValid(result);
        }
   }
```

It feels lighter and more intuitive. 

About the implementation : since it's just an overload, I prefered implementing an extension method that uses the original implementation, rather than adding a new method to the interface. The change is way less impacting and backward compatible.